### PR TITLE
New preprocessing script with centerline extraction

### DIFF
--- a/preprocessing/README.md
+++ b/preprocessing/README.md
@@ -1,4 +1,4 @@
-This folder contains the files required for preprocessing the data. The preprocessing script (using `Spinal Cord Toolbox v5.4`) `preprocess_zurich_centerline.sh` along with the procedure for quality control (QC) will be explained below. The file `exclude.yml` contains the list of subjects excluded from the dataset along with the reason for doing so. 
+This folder contains the files required for preprocessing the data. The preprocessing script (using `Spinal Cord Toolbox master-version`) `preprocess_zurich_centerline.sh` along with the procedure for two types of quality control (QC) will be explained below. 
 
 ## Preprocessing Steps
 
@@ -25,7 +25,7 @@ sct_run_batch -script preprocess_data.sh -path-data PATH_DATA -path-output PATH_
 ```
 where `PATH_DATA` is the path to the BIDS dataset folder, and `PATH_OUT` is where the output of preprocessing will be saved to. `PATH_OUT` will contain the folders `data_processed/` and `qc/` among others after a successful run.
 
-### Performing QC for Centerline Extraction
+### Performing Manual QC for Centerline Extraction
 To ensure that the extracted centerline is correct/meaningful, a QC has to be performed by going over all the subjects in the `index.html` file inside the `qc/` folder. The instructions for navigating `index.html` are provided on the page itself. For each subject, two outputs are generated: (1) the extracted centerline as seen on the axial slices and (2) the centerline as seen on the sagittal plane. The QC procedure is as follows:
 1. Look at both the outputs and make sure that the centerline is overlayed on the SC itself and does not erroneously lie outside the SC.
 2. Identify all the subjects where the automatic centerline detection fails (usually occurs in lumbar images) and download the QC fails. This should download a `.yml` file containing list of subjects required manual correction. 
@@ -34,20 +34,16 @@ To ensure that the extracted centerline is correct/meaningful, a QC has to be pe
     2. Note that the `output_path` should be: `derivatives/labels/sub-zhXX/ses-XX/anat/`. That is, the manually corrected SC centerline should exist as a derivative file. 
 
 
-TODO: The rest of the README
-
-### Running the QC Script
-After a successful preprocessing run, the next step is to do the QC to check for errors:
+### Performing Automatic QC for Preprocessed Output
+After a successful preprocessing run, the next step is to do the automatic QC to check for errors:
 ```
-python qc_preprocess.py -s PATH_OUT
+python qc_preprocess_sci-zurich.py -s PATH_OUT
 ```
-The `PATH_OUT` is the same output path used while running `sct_run_batch`.
+The `PATH_OUT` is the same output path used while running `sct_run_batch`. This folder should contain `data_processed` folder.'
 
 This QC script checks whether:
 
 1. the resolutions match between the two original sessions,
 2. the image and GT sizes are equivalent for each subject,
 3. the isotropic-resampling worked as expected,
-4. and most importantly, whether cropping of the original image with the SC mask erroneously crops out any SC lesions.
-
-NOTE: A mistake in the annotation process can result in lesions appearing _outside_ the SC. In such cases, those subjects were excluded from the dataset. More information on those subjects can be found in the `exclude.yml` file.
+4. and _most importantly_, whether cropping of the resampled image with the SC centerline mask erroneously crops out any lesions from the label masks.

--- a/preprocessing/README.md
+++ b/preprocessing/README.md
@@ -1,0 +1,53 @@
+This folder contains the files required for preprocessing the data. The preprocessing script (using `Spinal Cord Toolbox v5.4`) `preprocess_zurich_centerline.sh` along with the procedure for quality control (QC) will be explained below. The file `exclude.yml` contains the list of subjects excluded from the dataset along with the reason for doing so. 
+
+## Preprocessing Steps
+
+For a high-level overview, the preprocessing script iterates over all the subjects in the dataset and extracts the spinal cord (SC) centerline automatically (if the manual SC centerline is not available), or, uses the manual SC centerline (if available). This centerline mask is then dilated and further used to crop the original image so as to constrain the field-of-view to the close neighbourhood of the SC. 
+
+The flow of `preprocess_zurich_centerline.sh`, in detail, is as follows:
+
+1. A variable corresponding to the contrast to be preprocessed is defined. 
+2. The function `get_centerline_if_does_not_exist` checks whether the SC centerline mask exists within the dataset; if yes, uses the manual SC centerline mask, if not, then automatically extracts it using `sct_get_centerline`. The mask is then dilated using the `disk` object. Note that the centerline is extracted using the native resolution of the image. 
+3. The original image is resampled to a isotropic resolution. The dilated SC centerline mask is then used as the reference to crop the resampled image so as to focus on the spinal cord.
+4. Likewise, the ground truth SC lesion mask is resampled to the same isotropic resolution as the corresponding image and then cropped around the SC using the above-mentioned dilated centerline mask as the reference. 
+
+Note, the cropping is done around the entire region of the SC (so as to reduce size of the input images) and not just around the SC lesion. 
+
+### Running the Preprocessing Script
+The `sct_run_batch` is used to perform the preprocessing on all subjects with following command:
+```
+sct_run_batch -script preprocess_data.sh -path-data PATH_DATA -path-output PATH_OUT -jobs 64
+```
+
+If you intend to run the preprocessing only a few subjects (in this case, 4), then use the following command:
+```
+sct_run_batch -script preprocess_data.sh -path-data PATH_DATA -path-output PATH_OUT -jobs 64 -include-list sub-zhXX/ses-XX sub-zhXX/ses-XX sub-zhXX/ses-XX sub-zhXX/ses-XX
+```
+where `PATH_DATA` is the path to the BIDS dataset folder, and `PATH_OUT` is where the output of preprocessing will be saved to. `PATH_OUT` will contain the folders `data_processed/` and `qc/` among others after a successful run.
+
+### Performing QC for Centerline Extraction
+To ensure that the extracted centerline is correct/meaningful, a QC has to be performed by going over all the subjects in the `index.html` file inside the `qc/` folder. The instructions for navigating `index.html` are provided on the page itself. For each subject, two outputs are generated: (1) the extracted centerline as seen on the axial slices and (2) the centerline as seen on the sagittal plane. The QC procedure is as follows:
+1. Look at both the outputs and make sure that the centerline is overlayed on the SC itself and does not erroneously lie outside the SC.
+2. Identify all the subjects where the automatic centerline detection fails (usually occurs in lumbar images) and download the QC fails. This should download a `.yml` file containing list of subjects required manual correction. 
+3. For each failed subject, run the following command from the terminal: `sct_get_centerline -i <subject-name> -method viewer -gap 30 -qc qc-manual -o <output-path>_centerline-manual`. 
+    1. This command opens a GUI that allows you to select a few points on the SC so as to extract the centerline. Once you "Save and Quit" the GUI, two files `<subject_name>_centerline-manual.nii.gz` and `<subject_name>_centerline-manual.csv` files are saved in the `output_path` provided.
+    2. Note that the `output_path` should be: `derivatives/labels/sub-zhXX/ses-XX/anat/`. That is, the manually corrected SC centerline should exist as a derivative file. 
+
+
+TODO: The rest of the README
+
+### Running the QC Script
+After a successful preprocessing run, the next step is to do the QC to check for errors:
+```
+python qc_preprocess.py -s PATH_OUT
+```
+The `PATH_OUT` is the same output path used while running `sct_run_batch`.
+
+This QC script checks whether:
+
+1. the resolutions match between the two original sessions,
+2. the image and GT sizes are equivalent for each subject,
+3. the isotropic-resampling worked as expected,
+4. and most importantly, whether cropping of the original image with the SC mask erroneously crops out any SC lesions.
+
+NOTE: A mistake in the annotation process can result in lesions appearing _outside_ the SC. In such cases, those subjects were excluded from the dataset. More information on those subjects can be found in the `exclude.yml` file.

--- a/preprocessing/preprocess_zurich_centerline.sh
+++ b/preprocessing/preprocess_zurich_centerline.sh
@@ -1,0 +1,200 @@
+#!/bin/bash
+#
+# Preprocess data.
+#
+# Dependencies (versions):
+# - SCT (5.4)
+#
+# Usage:
+# sct_run_batch -script preprocess_data.sh -path-data <PATH-TO-DATASET> -path-output <PATH-TO-OUTPUT> -jobs -1
+
+# Manual segmentations or labels should be located under:
+# PATH_DATA/derivatives/labels/SUBJECT/ses-0X/anat/
+
+# The following global variables are retrieved from the caller sct_run_batch
+# but could be overwritten by uncommenting the lines below:
+# PATH_DATA_PROCESSED="~/data_processed"
+# PATH_RESULTS="~/results"
+# PATH_LOG="~/log"
+# PATH_QC="~/qc"
+
+# Global variables
+# CENTERLINE_METHOD="svm"  # method sct_deepseg_sc uses for centerline extraction: 'svm', 'cnn'
+CENTERLINE_EXTRACTION_METHOD="optic"  # method sct_get_centerline uses: 'optic', 'viewer' and 'fitseg'
+
+# Uncomment for full verbose
+set -x
+
+# Immediately exit if error
+set -e -o pipefail
+
+# Exit if user presses CTRL+C (Linux) or CMD+C (OSX)
+trap "echo Caught Keyboard Interrupt within script. Exiting now.; exit" INT
+
+# Print retrieved variables from the sct_run_batch script to the log (to allow easier debug)
+echo "Retrieved variables from the caller sct_run_batch:"
+echo "PATH_DATA: ${PATH_DATA}"
+echo "PATH_DATA_PROCESSED: ${PATH_DATA_PROCESSED}"
+echo "PATH_RESULTS: ${PATH_RESULTS}"
+echo "PATH_LOG: ${PATH_LOG}"
+echo "PATH_QC: ${PATH_QC}"
+
+# CONVENIENCE FUNCTIONS
+# ======================================================================================================================
+
+get_centerline_if_does_not_exist() {
+  ###
+  #  This function checks if a manual spinal cord centerline file already exists, then:
+  #    - If it does, copies it locally.
+  #    - If it doesn't, performs automatic spinal cord centerline extraction.
+  #  This allows you to add manual centerline files on a subject-by-subject basis without disrupting the pipeline.
+  ###
+  local file="$1"
+  local contrast="$2"
+  local centerline_extraction_method="$3"
+  # Update global variable with the centerline file name
+  FILECENTERLINE="${file}_centerline"
+  FILECENTERLINEMANUAL="${PATH_DATA}/derivatives/labels/${SUBJECT}/anat/${FILECENTERLINE}-manual.nii.gz"
+  echo
+  echo "Looking for manual centerline: $FILECENTERLINEMANUAL"
+  if [[ -e $FILECENTERLINEMANUAL ]]; then
+    echo "Found! Using manual centerline file."
+    rsync -avzh $FILECENTERLINEMANUAL ${FILECENTERLINE}.nii.gz
+    sct_qc -i ${file}.nii.gz -s ${FILECENTERLINE}.nii.gz -p sct_get_centerline -qc ${PATH_QC} -qc-subject ${SUBJECT}
+    # Generate sagittal QC (using sct_label_utils) to check that the centerline is correct on the sagittal plane
+    # NOTE: sct_label_vertebrae is raising an error when using manual centerline, so we use sct_label_utils instead
+    sct_qc -i ${file}.nii.gz -s ${FILECENTERLINE}.nii.gz -p sct_label_utils -qc ${PATH_QC} -qc-subject ${SUBJECT}
+  else
+    echo "Not found. Proceeding with automatic centerline extraction."
+    # Extract spinal cord centerline based on the specified centerline method
+    if [[ $centerline_extraction_method == "optic" ]]; then
+      sct_get_centerline -i ${file}.nii.gz -c $contrast -method optic -qc ${PATH_QC} -qc-subject ${SUBJECT} 
+      # Generate sagittal QC (using sct_label_vertebrae) to check that the centerline is correct on the sagittal plane
+      sct_qc -i ${file}.nii.gz -s ${FILECENTERLINE}.nii.gz -p sct_label_vertebrae -qc ${PATH_QC} -qc-subject ${SUBJECT}
+    # elif [[ $centerline_method == "svm" ]]; then
+    #   sct_deepseg_sc -i ${file}.nii.gz -c $contrast -centerline svm -qc ${PATH_QC} -qc-subject ${SUBJECT}
+    else
+      echo "Centerline extraction method = ${centerline_method} is not recognized!"
+      exit 1
+    fi
+  fi
+}
+
+# Retrieve input params and other params
+SUBJECT=$1
+
+# get starting time:
+start=`date +%s`
+
+
+# SCRIPT STARTS HERE
+# ==============================================================================
+# Display useful info for the log, such as SCT version, RAM and CPU cores available
+sct_check_dependencies -short
+
+# Go to folder where data will be copied and processed
+cd $PATH_DATA_PROCESSED
+
+# Copy BIDS-required files to processed data folder (e.g. list of participants)
+if [[ ! -f "participants.tsv" ]]; then
+  rsync -avzh $PATH_DATA/participants.tsv .
+fi
+if [[ ! -f "participants.json" ]]; then
+  rsync -avzh $PATH_DATA/participants.json .
+fi
+if [[ ! -f "dataset_description.json" ]]; then
+  rsync -avzh $PATH_DATA/dataset_description.json .
+fi
+if [[ ! -f "README" ]]; then
+  rsync -avzh $PATH_DATA/README .
+fi
+
+# Copy source images
+# Note: we use '/./' in order to include the sub-folder 'ses-0X'
+rsync -Ravzh $PATH_DATA/./$SUBJECT .
+
+# Copy segmentation ground truths (GT)
+mkdir -p derivatives/labels
+rsync -Ravzh $PATH_DATA/derivatives/labels/./$SUBJECT derivatives/labels/.
+
+# Go to subject folder for source images
+cd ${SUBJECT}/anat
+
+# Define variables
+# We do a substitution '/' --> '_' in case there is a subfolder 'ses-0X/'
+file="${SUBJECT//[\/]/_}"
+
+# Add suffix corresponding to contrast
+file=${file}_acq-sag_T2w
+
+# Make sure the image metadata is a valid JSON object
+if [[ ! -s ${file}.json ]]; then
+  echo "{}" >> ${file}.json
+fi
+
+# Spinal cord centerline extraction using the T2w contrast
+get_centerline_if_does_not_exist ${file} t2 ${CENTERLINE_EXTRACTION_METHOD}
+
+# define variable for naming the centerline output
+file_centerline="${FILECENTERLINE}"
+
+# Dilate the spinal cord (SC) centerline mask
+sct_maths -i ${file_centerline}.nii.gz -dilate 15 -shape disk -dim 1 -o ${file_centerline}_dilate.nii.gz
+
+# Define the absolute path for dilated centerline mask because the directory is changed later
+file_centerline_dilate=${PATH_DATA_PROCESSED}/${SUBJECT}/anat/${file_centerline}_dilate
+
+# Resample the image using linear interpolation
+sct_resample -i ${file}.nii.gz -mm 1x1x1 -x linear -o ${file}_resample.nii.gz
+
+# Use dilated SC centerline mask to crop the resampled image
+sct_crop_image -i ${file}_resample.nii.gz -m ${file_centerline_dilate}.nii.gz -o ${file}_crop.nii.gz
+
+# Go to subject folder for segmentation GTs
+cd $PATH_DATA_PROCESSED/derivatives/labels/$SUBJECT/anat
+
+# Define variables
+file_gt="${file}_lesion-manual"
+
+# Make sure the GT metadata is a valid JSON object
+if [[ ! -s ${file_gt}.json ]]; then
+  echo "{}" >> ${file_gt}.json
+fi
+
+# Resample the GT using linear interpolation
+sct_resample -i ${file_gt}.nii.gz -mm 1x1x1 -x linear -o ${file_gt}_resample.nii.gz
+
+# Crop the GT image using dilated SC centerline mask
+sct_crop_image -i ${file_gt}_resample.nii.gz -m ${file_centerline_dilate}.nii.gz -o ${file_gt}_crop.nii.gz
+
+# # Go back to the root output path
+# cd $PATH_OUTPUT
+
+# # Create and populate clean data processed folder for training
+# PATH_DATA_PROCESSED_CLEAN="${PATH_DATA_PROCESSED}_clean"
+
+# # Copy over required BIDs files
+# mkdir -p $PATH_DATA_PROCESSED_CLEAN $PATH_DATA_PROCESSED_CLEAN/${SUBJECT} $PATH_DATA_PROCESSED_CLEAN/${SUBJECT}/anat
+# rsync -avzh $PATH_DATA_PROCESSED/dataset_description.json $PATH_DATA_PROCESSED_CLEAN/
+# rsync -avzh $PATH_DATA_PROCESSED/participants.* $PATH_DATA_PROCESSED_CLEAN/
+# rsync -avzh $PATH_DATA_PROCESSED/README $PATH_DATA_PROCESSED_CLEAN/
+# rsync -avzh $PATH_DATA_PROCESSED/dataset_description.json $PATH_DATA_PROCESSED_CLEAN/derivatives/
+
+# # For lesion segmentation task, copy SC crops as inputs and lesion annotations as targets
+# # NOTE: we are not cropping the .json files as they are corrupted, thereby resulting in errors while using ivadomed
+# rsync -avzh $PATH_DATA_PROCESSED/${SUBJECT}/anat/${file}_crop.nii.gz $PATH_DATA_PROCESSED_CLEAN/${SUBJECT}/anat/${file}.nii.gz
+# # rsync -avzh $PATH_DATA_PROCESSED/${SUBJECT}/anat/${file}.json $PATH_DATA_PROCESSED_CLEAN/${SUBJECT}/anat/${file}.json
+# mkdir -p $PATH_DATA_PROCESSED_CLEAN/derivatives $PATH_DATA_PROCESSED_CLEAN/derivatives/labels $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT} $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/anat/
+# rsync -avzh $PATH_DATA_PROCESSED/derivatives/labels/${SUBJECT}/anat/${file_gt}_crop.nii.gz $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/anat/${file_gt}.nii.gz
+# # rsync -avzh $PATH_DATA_PROCESSED/derivatives/labels/${SUBJECT}/anat/${file_gt}.json $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/anat/${file_gt}.json
+
+
+# Display useful info for the log
+end=`date +%s`
+runtime=$((end-start))
+echo
+echo "~~~"
+echo "SCT version: `sct_version`"
+echo "Ran on:      `uname -nsr`"
+echo "Duration:    $(($runtime / 3600))hrs $((($runtime / 60) % 60))min $(($runtime % 60))sec"
+echo "~~~"

--- a/preprocessing/preprocess_zurich_centerline.sh
+++ b/preprocessing/preprocess_zurich_centerline.sh
@@ -142,13 +142,16 @@ file_centerline="${FILECENTERLINE}"
 sct_maths -i ${file_centerline}.nii.gz -dilate 15 -shape disk -dim 1 -o ${file_centerline}_dilate.nii.gz
 
 # Define the absolute path for dilated centerline mask because the directory is changed later
-file_centerline_dilate=${PATH_DATA_PROCESSED}/${SUBJECT}/anat/${file_centerline}_dilate
+fname_centerline_dilate=${PATH_DATA_PROCESSED}/${SUBJECT}/anat/${file_centerline}_dilate
 
 # Resample the image using linear interpolation
 sct_resample -i ${file}.nii.gz -mm 1x1x1 -x linear -o ${file}_resample.nii.gz
 
+# Resample the dilated centerline mask as well
+sct_resample -i ${fname_centerline_dilate}.nii.gz -mm 1x1x1 -x linear -o ${fname_centerline_dilate}_resample.nii.gz
+
 # Use dilated SC centerline mask to crop the resampled image
-sct_crop_image -i ${file}_resample.nii.gz -m ${file_centerline_dilate}.nii.gz -o ${file}_crop.nii.gz
+sct_crop_image -i ${file}_resample.nii.gz -m ${fname_centerline_dilate}_resample.nii.gz -o ${file}_crop.nii.gz
 
 # Go to subject folder for segmentation GTs
 cd $PATH_DATA_PROCESSED/derivatives/labels/$SUBJECT/anat
@@ -164,29 +167,29 @@ fi
 # Resample the GT using linear interpolation
 sct_resample -i ${file_gt}.nii.gz -mm 1x1x1 -x linear -o ${file_gt}_resample.nii.gz
 
-# Crop the GT image using dilated SC centerline mask
-sct_crop_image -i ${file_gt}_resample.nii.gz -m ${file_centerline_dilate}.nii.gz -o ${file_gt}_crop.nii.gz
+# Crop the GT image using resampled and dilated SC centerline mask
+sct_crop_image -i ${file_gt}_resample.nii.gz -m ${fname_centerline_dilate}_resample.nii.gz -o ${file_gt}_crop.nii.gz
 
-# # Go back to the root output path
-# cd $PATH_OUTPUT
+# Go back to the root output path
+cd $PATH_OUTPUT
 
-# # Create and populate clean data processed folder for training
-# PATH_DATA_PROCESSED_CLEAN="${PATH_DATA_PROCESSED}_clean"
+# Create and populate clean data processed folder for training
+PATH_DATA_PROCESSED_CLEAN="${PATH_DATA_PROCESSED}_clean"
 
-# # Copy over required BIDs files
-# mkdir -p $PATH_DATA_PROCESSED_CLEAN $PATH_DATA_PROCESSED_CLEAN/${SUBJECT} $PATH_DATA_PROCESSED_CLEAN/${SUBJECT}/anat
-# rsync -avzh $PATH_DATA_PROCESSED/dataset_description.json $PATH_DATA_PROCESSED_CLEAN/
-# rsync -avzh $PATH_DATA_PROCESSED/participants.* $PATH_DATA_PROCESSED_CLEAN/
-# rsync -avzh $PATH_DATA_PROCESSED/README $PATH_DATA_PROCESSED_CLEAN/
-# rsync -avzh $PATH_DATA_PROCESSED/dataset_description.json $PATH_DATA_PROCESSED_CLEAN/derivatives/
+# Copy over required BIDs files
+mkdir -p $PATH_DATA_PROCESSED_CLEAN $PATH_DATA_PROCESSED_CLEAN/${SUBJECT} $PATH_DATA_PROCESSED_CLEAN/${SUBJECT}/anat
+rsync -avzh $PATH_DATA_PROCESSED/dataset_description.json $PATH_DATA_PROCESSED_CLEAN/
+rsync -avzh $PATH_DATA_PROCESSED/participants.* $PATH_DATA_PROCESSED_CLEAN/
+rsync -avzh $PATH_DATA_PROCESSED/README $PATH_DATA_PROCESSED_CLEAN/
+rsync -avzh $PATH_DATA_PROCESSED/dataset_description.json $PATH_DATA_PROCESSED_CLEAN/derivatives/
 
-# # For lesion segmentation task, copy SC crops as inputs and lesion annotations as targets
-# # NOTE: we are not cropping the .json files as they are corrupted, thereby resulting in errors while using ivadomed
-# rsync -avzh $PATH_DATA_PROCESSED/${SUBJECT}/anat/${file}_crop.nii.gz $PATH_DATA_PROCESSED_CLEAN/${SUBJECT}/anat/${file}.nii.gz
-# # rsync -avzh $PATH_DATA_PROCESSED/${SUBJECT}/anat/${file}.json $PATH_DATA_PROCESSED_CLEAN/${SUBJECT}/anat/${file}.json
-# mkdir -p $PATH_DATA_PROCESSED_CLEAN/derivatives $PATH_DATA_PROCESSED_CLEAN/derivatives/labels $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT} $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/anat/
-# rsync -avzh $PATH_DATA_PROCESSED/derivatives/labels/${SUBJECT}/anat/${file_gt}_crop.nii.gz $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/anat/${file_gt}.nii.gz
-# # rsync -avzh $PATH_DATA_PROCESSED/derivatives/labels/${SUBJECT}/anat/${file_gt}.json $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/anat/${file_gt}.json
+# For lesion segmentation task, copy SC crops as inputs and lesion annotations as targets
+# NOTE: we are not cropping the .json files as they are corrupted, thereby resulting in errors while using ivadomed
+rsync -avzh $PATH_DATA_PROCESSED/${SUBJECT}/anat/${file}_crop.nii.gz $PATH_DATA_PROCESSED_CLEAN/${SUBJECT}/anat/${file}.nii.gz
+# rsync -avzh $PATH_DATA_PROCESSED/${SUBJECT}/anat/${file}.json $PATH_DATA_PROCESSED_CLEAN/${SUBJECT}/anat/${file}.json
+mkdir -p $PATH_DATA_PROCESSED_CLEAN/derivatives $PATH_DATA_PROCESSED_CLEAN/derivatives/labels $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT} $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/anat/
+rsync -avzh $PATH_DATA_PROCESSED/derivatives/labels/${SUBJECT}/anat/${file_gt}_crop.nii.gz $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/anat/${file_gt}.nii.gz
+# rsync -avzh $PATH_DATA_PROCESSED/derivatives/labels/${SUBJECT}/anat/${file_gt}.json $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/anat/${file_gt}.json
 
 
 # Display useful info for the log

--- a/preprocessing/qc_preprocess_sci-zurich.py
+++ b/preprocessing/qc_preprocess_sci-zurich.py
@@ -44,7 +44,7 @@ for subject in tqdm(subjects, desc='Iterating over Subjects'):
     temp_subject_path = os.path.join(args.sct_output_path, 'data_processed', subject)
     num_sessions_per_subject = sum(os.path.isdir(os.path.join(temp_subject_path, pth)) for pth in os.listdir(temp_subject_path))
     
-    for ses_idx in tqdm(range(1, num_sessions_per_subject+1), desc="Iterating over Sessions"):
+    for ses_idx in range(1, num_sessions_per_subject+1):
         # Get paths with session numbers
         session = 'ses-0' + str(ses_idx)
         subject_images_path = os.path.join(args.sct_output_path, 'data_processed', subject, session, 'anat')
@@ -69,7 +69,7 @@ for subject in tqdm(subjects, desc='Iterating over Subjects'):
         resolutions.append(resolution)
 
         # Read original and cropped subject ground-truths (GT)
-        gt_fpath = os.path.join(subject_labels_path, '%s_%s_acq-sag_T2w_lesion-manual.nii.gz' % (subject, session))
+        gt_fpath = os.path.join(subject_labels_path, '%s_%s_acq-sag_T2w_lesion-manual_resample.nii.gz' % (subject, session))
         gt_crop_fpath = os.path.join(subject_labels_path, '%s_%s_acq-sag_T2w_lesion-manual_crop.nii.gz' % (subject, session))
 
         gt = nib.load(gt_fpath)


### PR DESCRIPTION
This PR updates the preprocessing script by using `sct_get_centerline` for centerline extraction followed by cropping the (resampled) image around the using this centerline mask. Other minor inconsistencies about the comments in the preprocessing script, absolute/relative path variables are also fixed. 

Resolves #23, #24, #25, #26, #27, and mainly #28 . 