### PR TITLE
Update dataset conversion script for active learning

### DIFF
--- a/dataset-conversion/convert_bids_to_nnUNetv2_all_sci_data.py
+++ b/dataset-conversion/convert_bids_to_nnUNetv2_all_sci_data.py
@@ -74,11 +74,8 @@ def get_parser():
 
 def get_region_based_label(subject_labels_path, subject_label_file, subject_image_file, sub_ses_name, thr=0.5):
     
-    if sub_ses_name.startswith('sub-zh'):
-        # define path for sc seg file
-        subject_seg_file = os.path.join(subject_labels_path, f"{sub_ses_name}_acq-sag_T2w_seg-manual.nii.gz")
-    else:
-        subject_seg_file = os.path.join(subject_labels_path, f"{sub_ses_name}_T2w_seg-manual.nii.gz")
+    # define path for sc seg file
+    subject_seg_file = os.path.join(subject_labels_path, f"{sub_ses_name}_seg-manual.nii.gz")
     
     # check if the seg file exists
     if not os.path.exists(subject_seg_file):
@@ -86,22 +83,14 @@ def get_region_based_label(subject_labels_path, subject_label_file, subject_imag
         return None
 
     # create region-based label
-    seg_lesion_nii = create_region_based_label(subject_label_file, subject_seg_file, subject_image_file, sub_ses_name,
-                                               thr=thr)
+    seg_lesion_nii = create_region_based_label(subject_label_file, subject_seg_file, subject_image_file, 
+                                               sub_ses_name, thr=thr)
     
-    if sub_ses_name.startswith('sub-zh'):
-        # save the region-based label
-        nib.save(seg_lesion_nii, os.path.join(subject_labels_path,
-                                              f"{sub_ses_name}_acq-sag_T2w_seg-lesion-manual.nii.gz"))
+    # save the region-based label
+    nib.save(seg_lesion_nii, os.path.join(subject_labels_path, f"{sub_ses_name}_seg-lesion-manual.nii.gz"))
 
-        # overwrite the original label file with the region-based label
-        subject_label_file = os.path.join(subject_labels_path, f"{sub_ses_name}_acq-sag_T2w_seg-lesion-manual.nii.gz")
-    else:
-        # save the region-based label
-        nib.save(seg_lesion_nii, os.path.join(subject_labels_path, f"{sub_ses_name}_T2w_seg-lesion-manual.nii.gz"))
-
-        # overwrite the original label file with the region-based label
-        subject_label_file = os.path.join(subject_labels_path, f"{sub_ses_name}_T2w_seg-lesion-manual.nii.gz")
+    # overwrite the original label file with the region-based label
+    subject_label_file = os.path.join(subject_labels_path, f"{sub_ses_name}_seg-lesion-manual.nii.gz")
 
     return subject_label_file
 
@@ -275,6 +264,7 @@ def main():
                         binarize_label(subject_image_file_nnunet, subject_label_file_nnunet)
 
 
+            # subject is from sci-colorado
             else:
                 train_ctr += 1
                 subject_images_path = os.path.join(train_subjects[subject], 'anat')
@@ -283,11 +273,9 @@ def main():
 
                 subject_image_file = os.path.join(subject_images_path, f"{subject}_T2w.nii.gz")
                 subject_label_file = os.path.join(subject_labels_path, f"{subject}_T2w_lesion-manual.nii.gz")
-                # NOTE: if adding more contrasts, add them here by creating image-label files and the corresponding 
-                # nnunet convention names
 
                 # create the new convention names for nnunet
-                sub_name = str(Path(subject_image_file).name).split('_')[0]
+                sub_name = f"{str(Path(subject_image_file).name).replace('.nii.gz', '')}"
 
                 # use region-based labels if required
                 if args.region_based:                        
@@ -333,8 +321,7 @@ def main():
                                                       f"{subject}_{session}_acq-sag_T2w_lesion-manual.nii.gz")
 
                     # create the new convention names for nnunet
-                    sub_ses_name = str(Path(subject_image_file).name).split('_')[0] + '_' + \
-                                   str(Path(subject_image_file).name).split('_')[1]
+                    sub_ses_name = f"{str(Path(subject_image_file).name).replace('.nii.gz', '')}"
 
                     # use region-based labels if required
                     if args.region_based:                        
@@ -368,7 +355,7 @@ def main():
                 subject_label_file = os.path.join(subject_labels_path, f"{subject}_T2w_lesion-manual.nii.gz")
 
                 # create the new convention names for nnunet
-                sub_name = str(Path(subject_image_file).name).split('_')[0] # + '_' + str(Path(subject_image_file).name).split('_')[1]
+                sub_name = f"{str(Path(subject_image_file).name).replace('.nii.gz', '')}"
 
                 # use region-based labels if required
                 if args.region_based:                        

--- a/dataset-conversion/convert_bids_to_nnUNetv2_all_sci_data.py
+++ b/dataset-conversion/convert_bids_to_nnUNetv2_all_sci_data.py
@@ -38,6 +38,7 @@ import json
 import os
 import re
 import shutil
+import yaml
 from collections import OrderedDict
 from loguru import logger
 from sklearn.model_selection import train_test_split
@@ -64,6 +65,9 @@ def get_parser():
     parser.add_argument('--split', nargs='+', required=True, type=float, default=[0.8, 0.2],
                         help='Ratios of training (includes validation) and test splits lying between 0-1. Example: '
                              '--split 0.8 0.2')
+    # input yaml file containing list of axial subjects to include for active learning
+    parser.add_argument('--include-axial', type=str, default=None,
+                        help='Path to yaml file containing list of axial subjects to include for active learning.')
 
     return parser
 
@@ -140,6 +144,15 @@ def main():
         Path(path_out_imagesTsCol).mkdir(parents=True, exist_ok=True)
         Path(path_out_labelsTsCol).mkdir(parents=True, exist_ok=True)
 
+    # load the yaml file and convert to a list
+    if args.include_axial is not None:
+        with open(args.include_axial) as f:
+            axial_subjects = yaml.load(f, Loader=yaml.FullLoader)
+            # convert to a list
+            axial_subjects = list(axial_subjects.values())[0]
+
+    logger.info(f"Number of axial subjects in the YAML file: {len(axial_subjects)}")
+
     all_subjects, train_subjects, test_subjects = [], {}, {}
     # loop over the datasets
     for dataset in args.path_data:
@@ -183,43 +196,85 @@ def main():
                                                os.listdir(temp_subject_path))
 
                 for ses_idx in range(1, num_sessions_per_subject+1):
-                    train_ctr += 1
-                    # Get paths with session numbers
-                    session = 'ses-0' + str(ses_idx)
-
-                    subject_images_path = os.path.join(train_subjects[subject], session, 'anat')
-                    subject_labels_path = os.path.join(train_subjects[subject].replace(subject, ''), 'derivatives',
-                                                       'labels', subject, session, 'anat')
-
-                    subject_image_file = os.path.join(subject_images_path, f"{subject}_{session}_acq-sag_T2w.nii.gz")
-                    subject_label_file = os.path.join(subject_labels_path, f"{subject}_{session}_acq-sag_T2w_lesion-manual.nii.gz")
-
-                    # NOTE: if adding more contrasts, add them here by creating image-label files and the corresponding 
-                    # nnunet convention names
-
-                    # create the new convention names for nnunet
-                    sub_ses_name = str(Path(subject_image_file).name).split('_')[0] + '_' + str(Path(subject_image_file).name).split('_')[1]
                     
-                    # use region-based labels if required
-                    if args.region_based:                        
-                        # overwritten the subject_label_file with the region-based label
-                        subject_label_file = get_region_based_label(subject_labels_path, subject_label_file, subject_image_file, sub_ses_name, thr=0.5)
-                        if subject_label_file is None:
-                            print(f"Skipping since the region-based label could not be generated")
-                            continue
+                    if args.include_axial is not None and subject in train_ax_subs:
+                        
+                        orientations = ["sag", "ax"]
+                        for orientation in orientations:
+                            
+                            train_ctr += 1
+                            # Get paths with session numbers
+                            session = 'ses-0' + str(ses_idx)
 
-                    subject_image_file_nnunet = os.path.join(path_out_imagesTr,f"{args.dataset_name}_{sub_ses_name}_{train_ctr:03d}_0000.nii.gz")
-                    subject_label_file_nnunet = os.path.join(path_out_labelsTr,f"{args.dataset_name}_{sub_ses_name}_{train_ctr:03d}.nii.gz")
-                    
-                    # copy the files to new structure using symbolic links (prevents duplication of data and saves space)
-                    shutil.copyfile(subject_image_file, subject_image_file_nnunet)
-                    shutil.copyfile(subject_label_file, subject_label_file_nnunet)
+                            subject_images_path = os.path.join(train_subjects[subject], session, 'anat')
+                            subject_labels_path = os.path.join(train_subjects[subject].replace(subject, ''), 'derivatives',
+                                                            'labels', subject, session, 'anat')
+
+                            subject_image_file = os.path.join(subject_images_path, 
+                                                              f"{subject}_{session}_acq-{orientation}_T2w.nii.gz")
+                            subject_label_file = os.path.join(subject_labels_path, 
+                                                              f"{subject}_{session}_acq-{orientation}_T2w_lesion-manual.nii.gz")
+
+                            # create the new convention names for nnunet
+                            sub_ses_name = f"{str(Path(subject_image_file).name).replace('.nii.gz', '')}"
+                            
+                            # use region-based labels if required
+                            if args.region_based:                        
+                                # overwritten the subject_label_file with the region-based label
+                                subject_label_file = get_region_based_label(subject_labels_path, subject_label_file, 
+                                                                            subject_image_file, sub_ses_name, thr=0.5)
+                                if subject_label_file is None:
+                                    print(f"Skipping since the region-based label could not be generated")
+                                    continue
+
+                            subject_image_file_nnunet = os.path.join(path_out_imagesTr, 
+                                                                     f"{args.dataset_name}_{sub_ses_name}_{train_ctr:03d}_0000.nii.gz")
+                            subject_label_file_nnunet = os.path.join(path_out_labelsTr,
+                                                                     f"{args.dataset_name}_{sub_ses_name}_{train_ctr:03d}.nii.gz")
+                            # copy the files to new structure using symbolic links (prevents duplication of data and saves space)
+                            shutil.copyfile(subject_image_file, subject_image_file_nnunet)
+                            shutil.copyfile(subject_label_file, subject_label_file_nnunet)
+                                                
+                    else:                        
+                        train_ctr += 1
+                        # Get paths with session numbers
+                        session = 'ses-0' + str(ses_idx)
+
+                        subject_images_path = os.path.join(train_subjects[subject], session, 'anat')
+                        subject_labels_path = os.path.join(train_subjects[subject].replace(subject, ''), 'derivatives',
+                                                        'labels', subject, session, 'anat')
+
+                        # only take the sagittal orientation (as default)
+                        subject_image_file = os.path.join(subject_images_path, f"{subject}_{session}_acq-sag_T2w.nii.gz")
+                        subject_label_file = os.path.join(subject_labels_path, 
+                                                          f"{subject}_{session}_acq-sag_T2w_lesion-manual.nii.gz")
+
+                        # create the new convention names for nnunet
+                        sub_ses_name = f"{str(Path(subject_image_file).name).replace('.nii.gz', '')}"
+                        
+                        # use region-based labels if required
+                        if args.region_based:                        
+                            # overwritten the subject_label_file with the region-based label
+                            subject_label_file = get_region_based_label(subject_labels_path, subject_label_file, 
+                                                                        subject_image_file, sub_ses_name, thr=0.5)
+                            if subject_label_file is None:
+                                print(f"Skipping since the region-based label could not be generated")
+                                continue
+
+                        subject_image_file_nnunet = os.path.join(path_out_imagesTr, 
+                                                                 f"{args.dataset_name}_{sub_ses_name}_{train_ctr:03d}_0000.nii.gz")
+                        subject_label_file_nnunet = os.path.join(path_out_labelsTr,
+                                                                 f"{args.dataset_name}_{sub_ses_name}_{train_ctr:03d}.nii.gz")
+                        
+                        # copy the files to new structure using symbolic links (prevents duplication of data and saves space)
+                        shutil.copyfile(subject_image_file, subject_image_file_nnunet)
+                        shutil.copyfile(subject_label_file, subject_label_file_nnunet)
 
                     # binarize the label file only if region-based training is not set (since the region-based labels are already binarized)
                     if not args.region_based:
                         binarize_label(subject_image_file_nnunet, subject_label_file_nnunet)
-            
-            # subject is from sci-colorado or sci-paris
+
+
             else:
                 train_ctr += 1
                 subject_images_path = os.path.join(train_subjects[subject], 'anat')

--- a/dataset-conversion/convert_bids_to_nnUNetv2_all_sci_data.py
+++ b/dataset-conversion/convert_bids_to_nnUNetv2_all_sci_data.py
@@ -145,29 +145,26 @@ def main():
     for dataset in args.path_data:
         root = Path(dataset)
         
-        if "sci-paris" not in dataset:
-            # get the list of subjects in the root directory 
-            subjects = [subject for subject in sorted(os.listdir(root)) if subject.startswith('sub-')]
+        # get the list of subjects in the root directory 
+        subjects = [subject for subject in sorted(os.listdir(root)) if subject.startswith('sub-')]
 
-            # add to the list of all subjects
-            all_subjects.extend(subjects)
-            
-            # Get the training and test splits
-            tr_subs, te_subs = train_test_split(subjects, test_size=test_ratio, random_state=args.seed)
-            # update the train and test subjects dicts with the key as the subject and value as the path to the subject
-            train_subjects.update({sub: os.path.join(root, sub) for sub in tr_subs})
-            test_subjects.update({sub: os.path.join(root, sub) for sub in te_subs})
-        else:
-            # get the list of subjects in the root directory 
-            subjects = [subject for subject in sorted(os.listdir(root)) if subject.startswith('sub-')]
-            # logger.info(f"Total number of subjects in the Colorado dataset: {len(subjects)}")
-
-            # add to the list of all subjects
-            all_subjects.extend(subjects)
-
-            # add all the subjects to train_subjects dict
-            train_subjects.update({sub: os.path.join(root, sub) for sub in subjects})
+        # add to the list of all subjects
+        all_subjects.extend(subjects)
         
+        # Get the training and test splits
+        tr_subs, te_subs = train_test_split(subjects, test_size=test_ratio, random_state=args.seed)
+
+        # get the length of the number of subjects common to both tr_subs and axial
+        if args.include_axial is not None and "sci-zurich" in dataset:
+            train_ax_subs = list(set(tr_subs).intersection(axial_subjects))
+            logger.info(f"Number of Zurich axial subjects added to the training set: {len(train_ax_subs)}")
+            test_ax_subs = list(set(te_subs).intersection(axial_subjects))
+            logger.info(f"Corrected axial images in the original test split of seed {args.seed} (hence cannot be added to the training set): {test_ax_subs}")
+
+        # update the train and test subjects dicts with the key as the subject and value as the path to the subject
+        train_subjects.update({sub: os.path.join(root, sub) for sub in tr_subs})
+        test_subjects.update({sub: os.path.join(root, sub) for sub in te_subs})
+
     # print(f"Total number of subjects in the dataset: {len(all_subjects)}")
     # print(f"Total number of subjects in the training set: {len(train_subjects)}")
     # print(f"Total number of subjects in the test set: {len(test_subjects)}")


### PR DESCRIPTION
This PR updates the dataset conversion script by adding an option to include axial zurich images to the training set. 

More importantly, the script checks for the intersection between the training set subjects and the corrected axial subjects. Only the subjects common to the traning are used to enable proper comparison with the models trained _without_ active learning. 