### PR TITLE
Update README.md with SCT v6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,72 +12,36 @@ The model was trained on raw T2-weighted images of SCI patients from multiple (t
 <img width="1000" alt="figure2" src="https://github.com/ivadomed/model_seg_sci/assets/53445351/e858bde3-1b6e-4adb-8897-a6d323b64c0e">
 
 
-## Getting started
+## How to use the model
 
-### Dependencies
+### Install dependencies
 
-Install Spinal Cord Toolbox. Instructions can be found [here](https://spinalcordtoolbox.com/user_section/installation.html). 
+- [Spinal Cord Toolbox (SCT) v6.2](https://github.com/spinalcordtoolbox/spinalcordtoolbox/releases/tag/6.2) or higher -- follow the installation instructions [here](https://github.com/spinalcordtoolbox/spinalcordtoolbox?tab=readme-ov-file#installation)
+- [conda](https://conda.io/projects/conda/en/latest/user-guide/install/index.html) 
+- Python
 
-### Step 1: Cloning the Repository
-
-Open a terminal and clone the repository using the following command:
-
-~~~
-git clone https://github.com/ivadomed/model_seg_sci.git
-~~~
-
-### Step 2: Setting up the Environment
-
-The following commands show how to set up the environment. Note that the documentation assumes that the user has `conda` installed on their system. Instructions on installing `conda` can be found [here](https://conda.io/projects/conda/en/latest/user-guide/install/index.html).
-
-1. Create a conda environment with the following command:
-```
-conda create -n venv_nnunet python=3.9
-```
-
-2. Activate the environment with the following command:
-```
-conda activate venv_nnunet
-```
-
-3. Install the required packages with the following command:
-```
-cd model_seg_sci
-pip install -r packaging/requirements.txt
-```
- 
-### Step 3: Getting the Predictions
-
-ℹ️ To temporarily suppress warnings raised by the nnUNet, you can run the following three commands in the same terminal session as the above command:
+Once the dependencies are installed, download the latest SCIseg model:
 
 ```bash
-export nnUNet_raw="${HOME}/nnUNet_raw"
-export nnUNet_preprocessed="${HOME}/nnUNet_preprocessed"
-export nnUNet_results="${HOME}/nnUNet_results"
+sct_deepseg -install-task seg_sc_lesion_t2w_sci
 ```
 
-To segment a single image using the trained model, run the following command from the terminal. This assumes that the model has been downloaded and is available locally.
+### Getting the lesion and spinal cord segmentation
 
-For lesion segmentation:
+To segment a single image, run the following command: 
 
 ```bash
-python packaging/run_inference_single_subject.py -i sub-001_T2w.nii.gz -o sub-001_T2w_lesion_seg_nnunet.nii.gz -path-model /path/to/model -pred-type lesion
+sct_deepseg -i <INPUT> -task seg_sc_lesion_t2w_sci
 ```
 
-For spinal cord segmentation:
+For example:
 
 ```bash
-python packaging/run_inference_single_subject.py -i sub-001_T2w.nii.gz -o sub-001_T2w_seg_nnunet.nii.gz -path-model /path/to/model -pred-type sc
+sct_deepseg -i sub-001_T2w.nii.gz -task seg_sc_lesion_t2w_sci
 ```
 
-For segmenting a dataset of multiple subjects (instead of a single subject), run the following command from the 
-terminal.
-
-```bash
-python packaging/run_inference.py --path-dataset /path/to/test-dataset --path-out /path/to/output-directory --path-model /path/to/model --pred-type {sc-seg, lesion-seg, all}
-```
-
-ℹ️ The script also supports getting segmentations on a GPU. To do so, simply add the flag `--use-gpu` at the end of the above commands. By default, the inference is run on the CPU. It is useful to note that obtaining the predictions from the GPU is significantly faster than the CPU.
+The outputs will be saved in the same directory as the input image, with the suffix `_lesion_seg.nii.gz` for the lesion 
+and `_sc_seg.nii.gz` for the spinal cord.
 
 ## Citation Info
 

--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ The model was trained on raw T2-weighted images of SCI patients from multiple (t
 <img width="1000" alt="figure2" src="https://github.com/ivadomed/model_seg_sci/assets/53445351/e858bde3-1b6e-4adb-8897-a6d323b64c0e">
 
 
-## How to use the model
+## Using SCIseg
 
 ### Install dependencies
 
 - [Spinal Cord Toolbox (SCT) v6.2](https://github.com/spinalcordtoolbox/spinalcordtoolbox/releases/tag/6.2) or higher -- follow the installation instructions [here](https://github.com/spinalcordtoolbox/spinalcordtoolbox?tab=readme-ov-file#installation)
 - [conda](https://conda.io/projects/conda/en/latest/user-guide/install/index.html) 
-- Python
+- Python (v3.9)
 
 Once the dependencies are installed, download the latest SCIseg model:
 


### PR DESCRIPTION
This PR updates [README.md](https://github.com/ivadomed/model_seg_sci/blob/jv/update_README_SCTv62/README.md#how-to-use-the-model) with instructions on how to run the model using SCT v6.2 or higher.