### PR TITLE
Update QC script to work on all `sci` datasets

### DIFF
--- a/create_manual_sc_seg/generate_qc.sh
+++ b/create_manual_sc_seg/generate_qc.sh
@@ -1,15 +1,19 @@
 #!/bin/bash
 #
-# Preprocess data.
+# Generate lesion QC for T2w images.
 #
 # Dependencies (versions):
-# - SCT (5.4.0)
+# - SCT 6.0 and higher
 #
 # Usage:
-# sct_run_batch -script preprocess_data.sh -path-data <PATH-TO-DATASET> -path-output <PATH-TO-OUTPUT> -jobs <num-cpu-cores>
+# sct_run_batch -script generate_qc.sh -path-data <PATH-TO-DATASET> -path-output <PATH-TO-OUTPUT> -jobs <num-cpu-cores>
 
-# Manual segmentations or labels should be located under:
+# Lesion and SC labels should be located under:
 # PATH_DATA/derivatives/labels/SUBJECT/anat/
+
+# With the following naming convention:
+# file_gt="${file}_lesion-manual"
+# file_seg="${file}_seg-manual"
 
 # The following global variables are retrieved from the caller sct_run_batch
 # but could be overwritten by uncommenting the lines below:

--- a/create_manual_sc_seg/generate_qc.sh
+++ b/create_manual_sc_seg/generate_qc.sh
@@ -73,11 +73,6 @@ else
   file=${file}_acq-sag_T2w
 fi
 
-# Make sure the image metadata is a valid JSON object
-if [[ ! -s ${file}.json ]]; then
-  echo "{}" >> ${file}.json
-fi
-
 # Go to subject folder for segmentation GTs
 cd $PATH_DATA_PROCESSED/derivatives/labels/$SUBJECT/anat
 

--- a/create_manual_sc_seg/generate_qc.sh
+++ b/create_manual_sc_seg/generate_qc.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 #
-# Generate lesion QC for T2w images.
+# Generate QCs for T2w images:
+#     - sagittal lesion QC
+#     - single slice sagittal spinal cord QC (to check FOV coverage (C/Th/L))
 #
 # Dependencies (versions):
 # - SCT 6.0 and higher

--- a/create_manual_sc_seg/generate_qc.sh
+++ b/create_manual_sc_seg/generate_qc.sh
@@ -59,7 +59,13 @@ rsync -Ravzh $PATH_DATA/derivatives/labels/./${SUBJECT}/anat/${file}_*T2w* deriv
 cd ${SUBJECT}/anat
 
 # Add suffix corresponding to contrast
-file=${file}_acq-sag_T2w
+# for sci-colorado and sci-paris, use "T2w"
+if [[ $PATH_DATA =~ "colorado" ]] || [[ $PATH_DATA =~ "paris" ]]; then
+  file=${file}_T2w
+# for sci-zurich, use "acq-sag_T2w"
+else
+  file=${file}_acq-sag_T2w
+fi
 
 # Make sure the image metadata is a valid JSON object
 if [[ ! -s ${file}.json ]]; then

--- a/create_manual_sc_seg/generate_qc.sh
+++ b/create_manual_sc_seg/generate_qc.sh
@@ -84,10 +84,11 @@ file_seg="${file}_seg-manual"
 sct_maths -i ${file_gt}.nii.gz -bin 0 -o ${file_gt}_bin.nii.gz
 
 # Generate sagittal lesion QC
-# Note: -s is the SC segmentation provided to crop the image
+# Note: `-s` is the SC segmentation provided to crop the image
 sct_qc -i ${PATH_DATA_PROCESSED}/${SUBJECT}/anat/${file}.nii.gz -s ${file_seg}.nii.gz -d ${file_gt}_bin.nii.gz -p sct_deepseg_lesion -plane sagittal -qc ${PATH_QC} -qc-subject ${SUBJECT}
 
 # Generate single slice sagittal SC QC (to check FOV coverage (C/Th/L))
+# Note: `-p sct_label_vertebrae` is used to show a single sagittal slice (context: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4011#issuecomment-1561736362)
 sct_qc -i ${PATH_DATA_PROCESSED}/${SUBJECT}/anat/${file}.nii.gz -s ${file_seg}.nii.gz -p sct_label_vertebrae -qc ${PATH_QC} -qc-subject ${SUBJECT}
 
 # Display useful info for the log

--- a/create_manual_sc_seg/generate_qc.sh
+++ b/create_manual_sc_seg/generate_qc.sh
@@ -90,6 +90,9 @@ sct_maths -i ${file_gt}.nii.gz -bin 0 -o ${file_gt}_bin.nii.gz
 # Note: -s is the SC segmentation provided to crop the image
 sct_qc -i ${PATH_DATA_PROCESSED}/${SUBJECT}/anat/${file}.nii.gz -s ${file_seg}.nii.gz -d ${file_gt}_bin.nii.gz -p sct_deepseg_lesion -plane sagittal -qc ${PATH_QC} -qc-subject ${SUBJECT}
 
+# Generate single slice sagittal SC QC (to check FOV coverage (C/Th/L))
+sct_qc -i ${PATH_DATA_PROCESSED}/${SUBJECT}/anat/${file}.nii.gz -s ${file_seg}.nii.gz -p sct_label_vertebrae -qc ${PATH_QC} -qc-subject ${SUBJECT}
+
 # Display useful info for the log
 end=`date +%s`
 runtime=$((end-start))

--- a/create_manual_sc_seg/generate_qc.sh
+++ b/create_manual_sc_seg/generate_qc.sh
@@ -86,7 +86,8 @@ file_seg="${file}_seg-manual"
 # Binarize the GTs because QC only accepts binary images
 sct_maths -i ${file_gt}.nii.gz -bin 0 -o ${file_gt}_bin.nii.gz
 
-# Run the QC
+# Generate sagittal lesion QC
+# Note: -s is the SC segmentation provided to crop the image
 sct_qc -i ${PATH_DATA_PROCESSED}/${SUBJECT}/anat/${file}.nii.gz -s ${file_seg}.nii.gz -d ${file_gt}_bin.nii.gz -p sct_deepseg_lesion -plane sagittal -qc ${PATH_QC} -qc-subject ${SUBJECT}
 
 # Display useful info for the log

--- a/create_manual_sc_seg/generate_qc.sh
+++ b/create_manual_sc_seg/generate_qc.sh
@@ -79,11 +79,6 @@ cd $PATH_DATA_PROCESSED/derivatives/labels/$SUBJECT/anat
 file_gt="${file}_lesion-manual"
 file_seg="${file}_seg-manual"
 
-# Make sure the GT metadata is a valid JSON object
-if [[ ! -s ${file_gt}.json ]]; then
-  echo "{}" >> ${file_gt}.json
-fi
-
 # Binarize the GTs because QC only accepts binary images
 sct_maths -i ${file_gt}.nii.gz -bin 0 -o ${file_gt}_bin.nii.gz
 


### PR DESCRIPTION
This PR updates the [create_manual_sc_seg/generate_qc.sh](https://github.com/ivadomed/model_seg_sci/blob/1221fe5aca82f75977175d9958cb08efbbf093ff/create_manual_sc_seg/generate_qc.sh) script:
- to be compatible with all datasets (`sci-zurich`, `sci-colorado`, `sci-paris`)
- to generate single slice sagittal spinal cord QC (to check FOV coverage (C/Th/L))

QCs saved to `~/duke/projects/ml_sci_seg/paper/QCs`