### PR TITLE
Add between site lesion comparison

### DIFF
--- a/baselines/generate_figures.py
+++ b/baselines/generate_figures.py
@@ -440,7 +440,8 @@ def print_colorado_subjects_with_dice_0(df_concat):
 
 def compute_wilcoxon_test(df_concat, list_of_metrics):
     """
-    Compute Wilcoxon signed-rank test (two related paired samples -- a same subject for nnunet_3d vs nnunet_2d)
+    Compute Wilcoxon signed-rank test (nonparametric, paired -- two related paired samples -- a same subject for
+    nnunet_3d vs nnunet_2d)
     https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.wilcoxon.html
     :param df_concat: dataframe containing all the data
     :param list_of_metrics: list of metrics to compute the Wilcoxon test for
@@ -687,6 +688,7 @@ def main():
     # - compute Wilcoxon signed-rank test (nonparametric, paired) between nnunet_3d and nnunet_2d
     # - compute Mann-Whitney U test (nonparametric, independent samples) between site 1 and site 2
     if pred_type == 'lesion':
+        # nnunet_3d and nnunet_2d
         compute_wilcoxon_test(df_concat, list_of_metrics)
         # site 1 vs site 2
         compute_mann_whitney_u_test(df_concat, list_of_metrics)

--- a/baselines/generate_figures.py
+++ b/baselines/generate_figures.py
@@ -666,6 +666,9 @@ def main():
     # Concatenate the list of dataframes into a single dataframe
     df_concat = pd.concat(list_of_df, ignore_index=True)
 
+    # Drop filename column (to avoid error for the following '.groupby' and '.mean()' commands)
+    df_concat = df_concat.drop(columns=['filename'])
+
     # If a participant_id is duplicated (because the test image is presented across multiple seeds), average the
     # metrics across seeds for the same subject.
     df_concat = df_concat.groupby(['participant_id', 'session_id', 'site', 'method']).mean().reset_index()


### PR DESCRIPTION
This PR adds between site (site 1 vs site 2) lesion comparison.

Namely, I compute the Mann-Whitney U test (nonparametric, independent samples) between site 1 and site 2 for each segmentation metric (Dice, ...).

Details in individual commit messages.

<details><summary>output</summary>

```bash
Jaccard, nnunet_2d: Mann-Whitney U test between Zurich and Colorado: formatted p<0.001, unformatted p=0.000002
Dice, nnunet_2d: Mann-Whitney U test between Zurich and Colorado: formatted p<0.001, unformatted p=0.000002
Sensitivity, nnunet_2d: Mann-Whitney U test between Zurich and Colorado: formatted p<0.001, unformatted p=0.000001
Specificity, nnunet_2d: Mann-Whitney U test between Zurich and Colorado: formatted p=0.135, unformatted p=0.135324
PPV, nnunet_2d: Mann-Whitney U test between Zurich and Colorado: formatted p<0.05, unformatted p=0.021960
NPV, nnunet_2d: Mann-Whitney U test between Zurich and Colorado: formatted p<0.001, unformatted p=0.000046
RelativeVolumeError, nnunet_2d: Mann-Whitney U test between Zurich and Colorado: formatted p<0.001, unformatted p=0.000007
HausdorffDistance, nnunet_2d: Mann-Whitney U test between Zurich and Colorado: formatted p<0.01, unformatted p=0.006426
ContourMeanDistance, nnunet_2d: Mann-Whitney U test between Zurich and Colorado: formatted p<0.001, unformatted p=0.000031
SurfaceDistance, nnunet_2d: Mann-Whitney U test between Zurich and Colorado: formatted p<0.001, unformatted p=0.000014
PPVL, nnunet_2d: Mann-Whitney U test between Zurich and Colorado: formatted p<0.001, unformatted p=0.000001
SensL, nnunet_2d: Mann-Whitney U test between Zurich and Colorado: formatted p<0.01, unformatted p=0.001090
F1_score, nnunet_2d: Mann-Whitney U test between Zurich and Colorado: formatted p<0.001, unformatted p=0.000005
ExecutionTime[s], nnunet_2d: Mann-Whitney U test between Zurich and Colorado: formatted p<0.001, unformatted p=0.000000

Jaccard, nnunet_3d: Mann-Whitney U test between Zurich and Colorado: formatted p<0.001, unformatted p=0.000021
Dice, nnunet_3d: Mann-Whitney U test between Zurich and Colorado: formatted p<0.001, unformatted p=0.000020
Sensitivity, nnunet_3d: Mann-Whitney U test between Zurich and Colorado: formatted p<0.001, unformatted p=0.000175
Specificity, nnunet_3d: Mann-Whitney U test between Zurich and Colorado: formatted p=0.705, unformatted p=0.705337
PPV, nnunet_3d: Mann-Whitney U test between Zurich and Colorado: formatted p<0.05, unformatted p=0.023838
NPV, nnunet_3d: Mann-Whitney U test between Zurich and Colorado: formatted p<0.01, unformatted p=0.001859
RelativeVolumeError, nnunet_3d: Mann-Whitney U test between Zurich and Colorado: formatted p=0.129, unformatted p=0.128895
HausdorffDistance, nnunet_3d: Mann-Whitney U test between Zurich and Colorado: formatted p<0.001, unformatted p=0.000077
ContourMeanDistance, nnunet_3d: Mann-Whitney U test between Zurich and Colorado: formatted p<0.001, unformatted p=0.000001
SurfaceDistance, nnunet_3d: Mann-Whitney U test between Zurich and Colorado: formatted p<0.001, unformatted p=0.000200
PPVL, nnunet_3d: Mann-Whitney U test between Zurich and Colorado: formatted p<0.001, unformatted p=0.000004
SensL, nnunet_3d: Mann-Whitney U test between Zurich and Colorado: formatted p=0.064, unformatted p=0.064147
F1_score, nnunet_3d: Mann-Whitney U test between Zurich and Colorado: formatted p<0.001, unformatted p=0.000034
ExecutionTime[s], nnunet_3d: Mann-Whitney U test between Zurich and Colorado: formatted p<0.001, unformatted p=0.000000
```

</details>